### PR TITLE
http.Client no timeout in callMock

### DIFF
--- a/pkg/mockclient/client.go
+++ b/pkg/mockclient/client.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"testing"
-	"time"
 
 	"net/http"
 	"net/url"
@@ -85,8 +84,7 @@ func (c *Client) callMock(mockAPI, mockReqBody string) {
 	}
 
 	hc := &http.Client{
-		// Set timeout to 5s instead of default 30s
-		Timeout: time.Duration(5 * time.Second),
+		// No timeout
 	}
 	reader := strings.NewReader(mockReqBody)
 


### PR DESCRIPTION
```
Error:      	Received unexpected error:
        	Put http://localhost:8022/expectation: net/http: request canceled (Client.Timeout exceeded while awaiting headers)
```
Because of error above, I want to try no timeout.